### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/uk/co/ashtonbrsc/intentexplode/SettingsUtil.java
+++ b/app/src/main/java/uk/co/ashtonbrsc/intentexplode/SettingsUtil.java
@@ -12,6 +12,9 @@ import uk.co.ashtonbrsc.android.intentintercept.R;
 
 public class SettingsUtil {
 
+    private SettingsUtil() {
+    }
+
     public static void setupSettings(final Activity activity, PreferenceManager preferenceManager) {
 
         final Preference interceptEnabledPreference = preferenceManager


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.