### PR TITLE
[squid:S1155] Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/app/src/main/java/uk/co/ashtonbrsc/intentexplode/Explode.java
+++ b/app/src/main/java/uk/co/ashtonbrsc/intentexplode/Explode.java
@@ -275,7 +275,7 @@ public class Explode extends AppCompatActivity {
 
         flagsLayout.removeAllViews();
 		ArrayList<String> flagsStrings = getFlags();
-		if (flagsStrings.size() > 0) {
+		if (!flagsStrings.isEmpty()) {
 			for (String thisFlagString : flagsStrings) {
 				addTextToLayout(thisFlagString, Typeface.NORMAL, flagsLayout);
 			}
@@ -573,7 +573,7 @@ public class Explode extends AppCompatActivity {
 
 		stringBuilder.append(getResources().getString(R.string.flags_title_bold));
 		ArrayList<String> flagsStrings = getFlags();
-		if (flagsStrings.size() > 0) {
+		if (!flagsStrings.isEmpty()) {
 			for (String thisFlagString : flagsStrings) {
 				stringBuilder.append(thisFlagString).append(NEWLINE);
 			}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Ayman Abdelghany.