### PR TITLE
[squid:HiddenFieldCheck] Local variables should not shadow class fields

### DIFF
--- a/app/src/main/java/uk/co/ashtonbrsc/intentexplode/Explode.java
+++ b/app/src/main/java/uk/co/ashtonbrsc/intentexplode/Explode.java
@@ -219,15 +219,15 @@ public class Explode extends AppCompatActivity {
 
         if (originalExtras != null) {
             // bugfix #14: collect extras that are lost in the intent <-> string conversion
-            Bundle additionalExtas = new Bundle(originalExtras);
+            Bundle additionalExtras = new Bundle(originalExtras);
             for (String key : originalExtras.keySet()) {
                 if (copy.hasExtra(key)) {
-                    additionalExtas.remove(key);
+                    additionalExtras.remove(key);
                 }
             }
 
-            if (!additionalExtas.isEmpty()) {
-                this.additionalExtas = additionalExtas;
+            if (!additionalExtras.isEmpty()) {
+                this.additionalExtas = additionalExtras;
             }
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:HiddenFieldCheck - “Local variables should not shadow class fields”. 

You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck

Please let me know if you have any questions.
Ayman Abdelghany.