### PR TITLE
Refactored string resources introduced in #29: 

### DIFF
--- a/app/src/main/java/uk/co/ashtonbrsc/intentexplode/Explode.java
+++ b/app/src/main/java/uk/co/ashtonbrsc/intentexplode/Explode.java
@@ -65,8 +65,18 @@ import uk.co.ashtonbrsc.android.intentintercept.R;
  * shortcuts and the enabled/disabled state of interception.
  */
 public class Explode extends AppCompatActivity {
+	private static final String INTENT_EDITED = "intent_edited";
+	private static final int STANDARD_INDENT_SIZE_IN_DIP = 10;
+	private static final String NEWLINE = "\n<br>";
+	private static final String BLANK = " ";
 
-    private abstract class IntentUpdateTextWatcher implements TextWatcher {
+	private static final String NEWSEGMENT = NEWLINE + "------------" + NEWLINE;
+
+	private static final String BOLD_START = "<b><u>";
+	private static final String BOLD_END_BLANK = "</u></b>" + BLANK;
+	private static final String BOLD_END_NL = "</u></b>" + NEWLINE;
+
+	private abstract class IntentUpdateTextWatcher implements TextWatcher {
         private final TextView textView;
 
         IntentUpdateTextWatcher(TextView textView) {
@@ -103,10 +113,6 @@ public class Explode extends AppCompatActivity {
         }
     }
 
-    private static final String INTENT_EDITED = "intent_edited";
-	private static final int STANDARD_INDENT_SIZE_IN_DIP = 10;
-    private static final String NEWLINE = "\n<br>";
-
 	private ShareActionProvider shareActionProvider; // api-14 or compat
 	private EditText action;
 	private EditText data;
@@ -132,7 +138,7 @@ public class Explode extends AppCompatActivity {
 
     // support for onActivityResult
     private Integer lastResultCode = null;
-    private String lastResultIntent = null;
+    private Intent lastResultIntent = null;
 
     /** false: text-change-events are not active. */
 	private boolean textWatchersActive;
@@ -257,12 +263,9 @@ public class Explode extends AppCompatActivity {
 
         categoriesLayout.removeAllViews();
         Set<String> categories = editableIntent.getCategories();
-		StringBuilder stringBuilder = new StringBuilder();
 		if (categories != null) {
             categoriesHeader.setVisibility(View.VISIBLE);
-			stringBuilder.append(getResources().getString(R.string.categories));
 			for (String category : categories) {
-				stringBuilder.append(category).append(NEWLINE);
 				TextView categoryTextView = new TextView(this);
 				categoryTextView.setText(category);
 				categoryTextView.setTextAppearance(this, R.style.TextFlags);
@@ -280,70 +283,62 @@ public class Explode extends AppCompatActivity {
 				addTextToLayout(thisFlagString, Typeface.NORMAL, flagsLayout);
 			}
 		} else {
-			addTextToLayout(getResources().getString(R.string.none), Typeface.NORMAL, flagsLayout);
+			addTextToLayout(getString(R.string.no_items), Typeface.NORMAL, flagsLayout);
 		}
 
         extrasLayout.removeAllViews();
 		try {
+
 			Bundle intentBundle = editableIntent.getExtras();
 			if (intentBundle != null) {
-				Set<String> keySet = intentBundle.keySet();
-				stringBuilder.append(getResources().getString(R.string.bundle_title_bold));
+				Set<String> extraKeys = intentBundle.keySet();
 				int count = 0;
 
-				for (String key : keySet) {
+				for (String extraKey : extraKeys) {
 					count++;
-					Object thisObject = intentBundle.get(key);
-					addTextToLayout(getResources().getString(R.string.extra) + count, Typeface.BOLD,
-							extrasLayout);
-					String thisClass = thisObject.getClass().getName();
-					if (thisClass != null) {
-						addTextToLayout(getResources().getString(R.string.class_text) + thisClass,
-								Typeface.ITALIC,
+					Object extraItem = intentBundle.get(extraKey);
+					if (extraItem != null) {
+						String extraItemTypeName = extraItem.getClass().getName();
+
+						addTextToLayout("" + count, Typeface.BOLD, extrasLayout);
+
+						if (extraItemTypeName != null) {
+							addTextToLayout(getString(R.string.extra_item_type_name_title) + BLANK + extraItemTypeName,
+									Typeface.ITALIC,
+									STANDARD_INDENT_SIZE_IN_DIP, extrasLayout);
+						}
+
+						addTextToLayout(getString(R.string.extra_item_key_title) + BLANK + extraKey, Typeface.ITALIC,
 								STANDARD_INDENT_SIZE_IN_DIP, extrasLayout);
-					}
-					addTextToLayout(getResources().getString(R.string.key) + key, Typeface.ITALIC,
-							STANDARD_INDENT_SIZE_IN_DIP, extrasLayout);
-					if (thisObject instanceof String || thisObject instanceof Long
-							|| thisObject instanceof Integer
-							|| thisObject instanceof Boolean
-							|| thisObject instanceof Uri) {
-						addTextToLayout(getResources().getString(R.string.value) + thisObject
-										.toString(),
-								Typeface.ITALIC, STANDARD_INDENT_SIZE_IN_DIP,
-								extrasLayout);
-					} else if (thisObject instanceof ArrayList) {
-						addTextToLayout(getResources().getString(R.string.values), Typeface
-								.ITALIC, extrasLayout);
-						ArrayList thisArrayList = (ArrayList) thisObject;
-						for (Object thisArrayListObject : thisArrayList) {
-							addTextToLayout(thisArrayListObject.toString(),
+
+						if (extraItem instanceof ArrayList) {
+							addTextToLayout(getString(R.string.extra_item_type_name_list), Typeface
+									.ITALIC, extrasLayout);
+							ArrayList thisArrayList = (ArrayList) extraItem;
+							for (Object thisArrayListObject : thisArrayList) {
+								addTextToLayout(thisArrayListObject.toString(),
+										Typeface.ITALIC, STANDARD_INDENT_SIZE_IN_DIP,
+										extrasLayout);
+							}
+						} else {
+							addTextToLayout(getString(R.string.extra_item_value_title) + BLANK + extraItem
+											.toString(),
 									Typeface.ITALIC, STANDARD_INDENT_SIZE_IN_DIP,
 									extrasLayout);
+
 						}
 					}
 				}
 			} else {
-				addTextToLayout(getResources().getString(R.string.none), Typeface.NORMAL,
+				addTextToLayout(getString(R.string.no_items), Typeface.NORMAL,
 						extrasLayout);
 			}
 		} catch (Exception e) {
 			// TODO Should make this red to highlight error
-			addTextToLayout(getResources().getString(R.string.error_extracting_extras), Typeface.NORMAL, extrasLayout);
+			addTextToLayout(getString(R.string.error_extracting_extras), Typeface.NORMAL, extrasLayout);
 			e.printStackTrace();
 		}
 
-		// resolveInfo = pm.queryIntentServices(intent, 0);
-		// stringBuilder.append("<br><b><u>" + resolveInfo.size()
-		// + " services match this intent:</u></b><br>");
-		// for (int i = 0; i < resolveInfo.size(); i++) {
-		// ResolveInfo info = resolveInfo.get(i);
-		// ActivityInfo activityinfo = info.activityInfo;
-		// stringBuilder.append(activityinfo.packageName + "<br>");
-		// }
-
-		// intentDetailsHtml = stringBuilder.toString();
-		// (((TextView) findViewById(R.id.text))).setText(intentDetailsHtml);
 		refreshUI();
 	}
 
@@ -380,24 +375,24 @@ public class Explode extends AppCompatActivity {
 		List<ResolveInfo> resolveInfo = pm.queryIntentActivities(
                 editableIntent, 0);
 
+		activitiesHeader.setText(getString(R.string.intent_matching_activities_title));
+
 		// Remove Intent Intercept from matching activities
 		int numberOfMatchingActivities = resolveInfo.size() - 1;
 
 		if (numberOfMatchingActivities < 1) {
             resendIntentButton.setEnabled(false);
-			activitiesHeader.setText(getResources().getString(R.string.no_activities_match_intent));
+			addTextToLayout(getString(R.string.no_items), Typeface.NORMAL, activitiesLayout);
+
 		} else {
             resendIntentButton.setEnabled(true);
-			activitiesHeader.setText(getResources().getQuantityString(R.plurals.activities_match_intent,
-					numberOfMatchingActivities, numberOfMatchingActivities));
 			for (int i = 0; i <= numberOfMatchingActivities; i++) {
 				ResolveInfo info = resolveInfo.get(i);
 				ActivityInfo activityinfo = info.activityInfo;
 				if (!activityinfo.packageName.equals(getPackageName())) {
-					addTextToLayout(activityinfo.loadLabel(pm) + getResources().getString(R
-									.string.open_bracket)
-							+ activityinfo.packageName + getResources().getString(R.string.dash)
-							+ activityinfo.name + getResources().getString(R.string.close_bracket), Typeface
+					addTextToLayout(activityinfo.loadLabel(pm) + " ("
+							+ activityinfo.packageName + " - "
+							+ activityinfo.name + ")", Typeface
 									.NORMAL,
 							activitiesLayout);
 				}
@@ -427,16 +422,16 @@ public class Explode extends AppCompatActivity {
 	}
 
 	private void setupVariables() {
-		action = (EditText) findViewById(R.id.action);
-		data = (EditText) findViewById(R.id.data);
-		type = (EditText) findViewById(R.id.type);
-        uri = (EditText) findViewById(R.id.uri);
-		categoriesHeader = (TextView) findViewById(R.id.categories_header);
-		categoriesLayout = (LinearLayout) findViewById(R.id.categories_layout);
-		flagsLayout = (LinearLayout) findViewById(R.id.flags_layout);
-		extrasLayout = (LinearLayout) findViewById(R.id.extras_layout);
-		activitiesHeader = (TextView) findViewById(R.id.activities_header);
-		activitiesLayout = (LinearLayout) findViewById(R.id.activities_layout);
+		action = (EditText) findViewById(R.id.action_edit);
+		data = (EditText) findViewById(R.id.data_edit);
+		type = (EditText) findViewById(R.id.type_edit);
+        uri = (EditText) findViewById(R.id.uri_edit);
+		categoriesHeader = (TextView) findViewById(R.id.intent_categories_header);
+		categoriesLayout = (LinearLayout) findViewById(R.id.intent_categories_layout);
+		flagsLayout = (LinearLayout) findViewById(R.id.intent_flags_layout);
+		extrasLayout = (LinearLayout) findViewById(R.id.intent_extras_layout);
+		activitiesHeader = (TextView) findViewById(R.id.intent_matching_activities_header);
+		activitiesLayout = (LinearLayout) findViewById(R.id.intent_matchin_activities_layout);
 		resendIntentButton = (Button) findViewById(R.id.resend_intent_button);
 		resetIntentButton = (Button) findViewById(R.id.reset_intent_button);
 
@@ -483,7 +478,7 @@ public class Explode extends AppCompatActivity {
 	}
 
     private void showResetIntentButton(boolean visible) {
-		resendIntentButton.setText(R.string.send_edited_intent_button);
+		resendIntentButton.setText(R.string.button_title_send_edited_intent);
 		resetIntentButton.setVisibility((visible) ? View.VISIBLE : View.GONE);
 	}
 
@@ -510,7 +505,7 @@ public class Explode extends AppCompatActivity {
 	private void copyIntentDetails() {
 		ClipboardManager clipboard = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
 		clipboard.setText(getIntentDetailsString());
-		Toast.makeText(this, R.string.intent_details_copied_to_clipboard,
+		Toast.makeText(this, R.string.message_intent_details_copied_to_clipboard,
 				Toast.LENGTH_SHORT).show();
 	}
 
@@ -530,98 +525,21 @@ public class Explode extends AppCompatActivity {
 
 	private Intent createShareIntent() {
 		Intent share = new Intent(Intent.ACTION_SEND);
-		share.setType(getResources().getString(R.string.text_plain));
+		share.setType(getString(R.string.mime_type_text_plain));
 		share.putExtra(Intent.EXTRA_TEXT, getIntentDetailsString());
 		return share;
 	}
 
-	private Spanned getIntentDetailsString() { // TODO make sure this has all
-												// the details
-		StringBuilder stringBuilder = new StringBuilder();
+	private Spanned getIntentDetailsString() {
+		StringBuilder result = new StringBuilder();
 
         // k3b so intent can be reloaded using
         // Intent.parseUri("Intent:....", Intent.URI_INTENT_SCHEME)
-        stringBuilder.append(getUri(editableIntent)).append(NEWLINE);
+        result.append(getUri(editableIntent))
+				.append(NEWSEGMENT);
 
-        // support for onActivityResult
-        if (this.lastResultCode != null) {
-            stringBuilder.append(getResources().getString(R.string.last_result)).append(this.lastResultCode
-					.toString
-					());
-
-            if (this.lastResultIntent != null) {
-                stringBuilder.append(getResources().getString(R.string.data))
-						.append(lastResultIntent);
-            }
-            stringBuilder.append(NEWLINE);
-        }
-
-        stringBuilder.append(NEWLINE).append(getResources().getString(R.string.action_bold))
-				.append(editableIntent.getAction()).append(NEWLINE);
-		stringBuilder.append(getResources().getString(R.string.data_bold))
-				.append(editableIntent.getData()).append(NEWLINE);
-		stringBuilder.append(getResources().getString(R.string.type_bold))
-				.append(editableIntent.getType()).append(NEWLINE);
-
-		Set<String> categories = editableIntent.getCategories();
-		if (categories != null) {
-			stringBuilder.append(getResources().getString(R.string.categories_title_bold));
-			for (String category : categories) {
-				stringBuilder.append(category).append(NEWLINE);
-			}
-		}
-
-		stringBuilder.append(getResources().getString(R.string.flags_title_bold));
-		ArrayList<String> flagsStrings = getFlags();
-		if (!flagsStrings.isEmpty()) {
-			for (String thisFlagString : flagsStrings) {
-				stringBuilder.append(thisFlagString).append(NEWLINE);
-			}
-		} else {
-			stringBuilder.append(getResources().getString(R.string.none)).append(NEWLINE);
-		}
-
-		try {
-			Bundle intentBundle = editableIntent.getExtras();
-			if (intentBundle != null) {
-				Set<String> keySet = intentBundle.keySet();
-				stringBuilder.append(getResources().getString(R.string.extras_title_bold));
-				int count = 0;
-
-				for (String key : keySet) {
-					count++;
-					Object thisObject = intentBundle.get(key);
-					stringBuilder.append(getResources().getQuantityString(R.plurals.extra_count,
-							count, count));
-					String thisClass = thisObject.getClass().getName();
-					if (thisClass != null) {
-						stringBuilder.append(getResources().getString(R.string.class_text)).append(thisClass)
-								.append(NEWLINE);
-					}
-					stringBuilder.append(getResources().getString(R.string.key)).append(key).append
-							(NEWLINE);
-
-					if (thisObject instanceof String || thisObject instanceof Long
-							|| thisObject instanceof Integer
-							|| thisObject instanceof Boolean
-							|| thisObject instanceof Uri) {
-						stringBuilder.append(getResources().getString(R.string.value)).append(thisObject
-								.toString())
-								.append(NEWLINE);
-					} else if (thisObject instanceof ArrayList) {
-						stringBuilder.append(getResources().getString(R.string.values_break));
-						ArrayList thisArrayList = (ArrayList) thisObject;
-						for (Object thisArrayListObject : thisArrayList) {
-							stringBuilder.append(thisArrayListObject.toString()).append(NEWLINE);
-						}
-					}
-				}
-			}
-		} catch (Exception e) {
-			stringBuilder.append(getResources().getString(R.string.bundle_title_bold_uppercase));
-			stringBuilder.append(getResources().getString(R.string.error_extracting_extras_red));
-			e.printStackTrace();
-		}
+		appendIntentDetails(result, editableIntent, true)
+				.append(NEWSEGMENT);
 
 		PackageManager pm = getPackageManager();
 		List<ResolveInfo> resolveInfo = pm.queryIntentActivities(
@@ -630,34 +548,126 @@ public class Explode extends AppCompatActivity {
 		// Remove Intent Intercept from matching activities
 		int numberOfMatchingActivities = resolveInfo.size() - 1;
 
+		appendHeader(result, R.string.intent_matching_activities_title);
 		if (numberOfMatchingActivities < 1) {
-			stringBuilder
-					.append(getResources().getString(R.string.no_activities_match_intent_title_bold));
+			appendHeader(result, R.string.no_items);
 		} else {
-			stringBuilder.append(getResources().getQuantityString(R.plurals
-					.activites_match_intent_title_bold, numberOfMatchingActivities,
-					numberOfMatchingActivities));
 			for (int i = 0; i <= numberOfMatchingActivities; i++) {
 				ResolveInfo info = resolveInfo.get(i);
 				ActivityInfo activityinfo = info.activityInfo;
 				if (!activityinfo.packageName.equals(getPackageName())) {
-					stringBuilder.append(activityinfo.loadLabel(pm))
-							.append(getResources().getString(R.string.open_bracket))
+					result.append(BOLD_START).append(activityinfo.loadLabel(pm))
+							.append(BOLD_END_BLANK).append(" (")
 							.append(activityinfo.packageName)
-							.append(getResources().getString(R.string.dash))
+							.append(" - ")
 							.append(activityinfo.name)
-							.append(getResources().getString(R.string.close_bracket_break));
+							.append(")").append(NEWLINE);
 				}
 			}
 		}
+		
+		// support for onActivityResult
+		if (this.lastResultCode != null) {
+			result.append(NEWSEGMENT);
+			appendHeader(result, R.string.last_result_header_title);
+			appendNameValue(result, R.string.last_result_code_title, this.lastResultCode);
 
-		return Html.fromHtml(stringBuilder.toString());
+			if (this.lastResultIntent != null) {
+				appendIntentDetails(result, lastResultIntent, false);
+			}
+		}
+		
+		return Html.fromHtml(result.toString());
 	}
+
+	private StringBuilder appendIntentDetails(StringBuilder result, Intent intent, boolean detailed) {
+		if (detailed) appendNameValue(result, R.string.intent_action_title, intent.getAction());
+
+		appendNameValue(result, R.string.intent_data_title, intent.getData());
+		appendNameValue(result, R.string.intent_mime_type_title, intent.getType());
+		appendNameValue(result, R.string.intent_uri_title, getUri(intent));
+
+		Set<String> categories = intent.getCategories();
+		if ((categories != null) && (categories.size() > 0)) {
+			appendHeader(result, R.string.intent_categories_title);
+			for (String category : categories) {
+				result.append(category).append(NEWLINE);
+			}
+		}
+
+		if (detailed) {
+			appendHeader(result, R.string.intent_flags_title);
+			ArrayList<String> flagsStrings = getFlags();
+			if (!flagsStrings.isEmpty()) {
+				for (String thisFlagString : flagsStrings) {
+					result.append(thisFlagString).append(NEWLINE);
+				}
+			} else {
+				result.append(getString(R.string.no_items)).append(NEWLINE);
+			}
+		}
+
+		try {
+			Bundle intentBundle = intent.getExtras();
+			if (intentBundle != null) {
+				Set<String> keySet = intentBundle.keySet();
+				appendHeader(result, R.string.intent_extras_title);
+				int count = 0;
+
+				for (String key : keySet) {
+					count++;
+					Object thisObject = intentBundle.get(key);
+					result.append(BOLD_START).append(count).append(BOLD_END_BLANK);
+					String thisClass = thisObject.getClass().getName();
+					if (thisClass != null) {
+						result.append(getString(R.string.extra_item_type_name_title)).append(BLANK)
+								.append(thisClass).append(NEWLINE);
+					}
+					result.append(getString(R.string.extra_item_key_title)).append(BLANK)
+							.append(key).append(NEWLINE);
+
+					if (thisObject instanceof String || thisObject instanceof Long
+							|| thisObject instanceof Integer
+							|| thisObject instanceof Boolean
+							|| thisObject instanceof Uri) {
+						result.append(getString(R.string.extra_item_value_title)).append(BLANK)
+								.append(thisObject.toString())
+								.append(NEWLINE);
+					} else if (thisObject instanceof ArrayList) {
+						result.append(getString(R.string.extra_item_type_name_list)).append(NEWLINE);
+						ArrayList thisArrayList = (ArrayList) thisObject;
+						for (Object thisArrayListObject : thisArrayList) {
+							result.append(thisArrayListObject.toString()).append(NEWLINE);
+						}
+					}
+				}
+			}
+		} catch (Exception e) {
+			appendHeader(result, R.string.intent_extras_title);
+			result.append("<font color='red'>").append(getString(R.string.error_extracting_extras)).append("</font>").append(NEWLINE);
+			e.printStackTrace();
+		}
+		return result;
+	}
+
+	private StringBuilder appendNameValue(StringBuilder result, int keyId, Object value) {
+		if (value  != null) {
+			result.append(BOLD_START).append(getString(keyId)).append(BOLD_END_BLANK)
+					.append(value).append(NEWLINE);
+		}
+		return result;
+	}
+
+	private StringBuilder appendHeader(StringBuilder result, int keyId) {
+		result.append(BOLD_START).append(getString(keyId)).append(BOLD_END_NL);
+		return result;
+	}
+
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
 		getMenuInflater().inflate(R.menu.menu, menu);
-		MenuItem actionItem = menu.findItem(R.id.share);
+		MenuItem actionItem = menu.findItem(R.id.menu_share);
 
         shareActionProvider = (ShareActionProvider) MenuItemCompat.getActionProvider(actionItem);
 
@@ -675,7 +685,7 @@ public class Explode extends AppCompatActivity {
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		switch (item.getItemId()) {
-		case R.id.copy:
+		case R.id.menu_copy:
 			copyIntentDetails();
 			break;
 		}
@@ -710,11 +720,16 @@ public class Explode extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         this.lastResultCode = Integer.valueOf(resultCode);
-        this.lastResultIntent = getUri(data);
+        this.lastResultIntent = data;
         super.onActivityResult(requestCode, resultCode, data);
         setResult(resultCode, data);
         refreshUI();
-    }
+
+		Uri uri = (data == null) ? null : data.getData();
+		Toast.makeText(Explode.this,
+				getString(R.string.last_result_message, getString(R.string.last_result_header_title), ""+requestCode, uri),
+				Toast.LENGTH_LONG).show();
+	}
 
     private static String getUri(Intent src) {
 		return (src != null) ? src.toUri(Intent.URI_INTENT_SCHEME) : null;

--- a/app/src/main/java/uk/co/ashtonbrsc/intentexplode/SettingsUtil.java
+++ b/app/src/main/java/uk/co/ashtonbrsc/intentexplode/SettingsUtil.java
@@ -18,7 +18,7 @@ public class SettingsUtil {
     public static void setupSettings(final Activity activity, PreferenceManager preferenceManager) {
 
         final Preference interceptEnabledPreference = preferenceManager
-                .findPreference(activity.getString(R.string.intercept_enable_pref));
+                .findPreference("interceptEnabled");
 
         interceptEnabledPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
 
@@ -39,15 +39,15 @@ public class SettingsUtil {
         });
 
         Preference sendTestIntentPreference = preferenceManager
-                .findPreference(activity.getString(R.string.send_test_intent_pref));
+                .findPreference("sendTestIntent");
         sendTestIntentPreference.setOnPreferenceClickListener(new Preference
                 .OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 Intent intent = ShareCompat.IntentBuilder.from(activity).setChooserTitle
-                        (activity.getString(R.string.select_intent_intercept)).setType(activity
-                        .getString(R.string.plain_text))
-                        .setText(activity.getString(R.string.test_intent)).createChooserIntent();
+                        (activity.getString(R.string.send_test_intent_chooser_title)).setType(activity
+                        .getString(R.string.mime_type_text_plain))
+                        .setText(activity.getString(R.string.send_test_intent_content)).createChooserIntent();
                 activity.startActivity(intent);
                 return true;
             }

--- a/app/src/main/res/layout/explode.xml
+++ b/app/src/main/res/layout/explode.xml
@@ -25,63 +25,63 @@
                 style="@style/TextHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/action"/>
+                android:text="@string/intent_action_title"/>
 
             <uk.co.ashtonbrsc.intentexplode.widget.BlockEnterEditText
-                android:id="@+id/action"
+                android:id="@+id/action_edit"
                 style="@style/EditTextNoSuggestion"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/null_text" />
+                android:hint="@string/no_value_text" />
 
             <uk.co.ashtonbrsc.intentexplode.widget.UnderlinedTextView
                 style="@style/TextHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/data_upper_case" />
+                android:text="@string/intent_data_title" />
 
             <uk.co.ashtonbrsc.intentexplode.widget.BlockEnterEditText
-                android:id="@+id/data"
+                android:id="@+id/data_edit"
                 style="@style/EditTextNoSuggestion"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/null_text" />
+                android:hint="@string/no_value_text" />
 
             <uk.co.ashtonbrsc.intentexplode.widget.UnderlinedTextView
                 style="@style/TextHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/type"/>
+                android:text="@string/intent_mime_type_title"/>
 
             <uk.co.ashtonbrsc.intentexplode.widget.BlockEnterEditText
-                android:id="@+id/type"
+                android:id="@+id/type_edit"
                 style="@style/EditTextNoSuggestion"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/null_text" />
+                android:hint="@string/no_value_text" />
 
             <uk.co.ashtonbrsc.intentexplode.widget.UnderlinedTextView
                 style="@style/TextHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/uri" />
+                android:text="@string/intent_uri_title" />
 
             <uk.co.ashtonbrsc.intentexplode.widget.BlockEnterEditText
-                android:id="@+id/uri"
+                android:id="@+id/uri_edit"
                 style="@style/EditTextNoSuggestion"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/null_text" />
+                android:hint="@string/no_value_text" />
 
             <uk.co.ashtonbrsc.intentexplode.widget.UnderlinedTextView
-                android:id="@+id/categories_header"
+                android:id="@+id/intent_categories_header"
                 style="@style/TextHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/categories_upper_case" />
+                android:text="@string/intent_categories_title" />
 
             <LinearLayout
-                android:id="@+id/categories_layout"
+                android:id="@+id/intent_categories_layout"
                 style="@style/ListLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -91,10 +91,10 @@
                 style="@style/TextHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/flags" />
+                android:text="@string/intent_flags_title" />
 
             <LinearLayout
-                android:id="@+id/flags_layout"
+                android:id="@+id/intent_flags_layout"
                 style="@style/ListLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
@@ -103,24 +103,24 @@
                 style="@style/TextHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/extras" />
+                android:text="@string/intent_extras_title" />
 
             <LinearLayout
-                android:id="@+id/extras_layout"
+                android:id="@+id/intent_extras_layout"
                 style="@style/ListLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical" />
 
             <uk.co.ashtonbrsc.intentexplode.widget.UnderlinedTextView
-                android:id="@+id/activities_header"
+                android:id="@+id/intent_matching_activities_header"
                 style="@style/TextHeader"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/matching_activities" />
+                android:text="@string/intent_matching_activities_title" />
 
             <LinearLayout
-                android:id="@+id/activities_layout"
+                android:id="@+id/intent_matchin_activities_layout"
                 style="@style/ListLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -148,7 +148,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:onClick="onResetIntent"
-            android:text="@string/reset_intent"
+            android:text="@string/button_title_reset_intent"
             android:visibility="gone" />
 
         <Button
@@ -158,7 +158,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:onClick="onSendIntent"
-            android:text="@string/resend_intent" />
+            android:text="@string/button_title_resend_intent" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -3,17 +3,17 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/copy"
+        android:id="@+id/menu_copy"
         android:icon="@drawable/ic_action_content_copy"
         app:showAsAction="ifRoom"
-        android:title="@string/copy">
+        android:title="@string/menu_copy_title">
     </item>
     <item
-        android:id="@+id/share"
+        android:id="@+id/menu_share"
         android:icon="@drawable/ic_action_share"
         app:showAsAction="always"
         app:actionProviderClass="android.support.v7.widget.ShareActionProvider"
-        android:title="@string/share">
+        android:title="@string/menu_share_title">
     </item>
 
 </menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,22 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Intent Abfänger</string>
-    <string name="copy">Kopieren</string>
-    <string name="license_title">Lizenz</string>
-    <string name="visit_website_title">intrications.com besuchen</string>
-    <string name="visit_google_plus_title">Intrications auf Google+ besuchen</string>
-    <string name="view_source_code_summary">Den \'Intent Abfänger\'-Quellcode auf GitHub ansehen</string>
-    <string name="view_my_other_apps_title">Andere Apps von Intrications ansehen</string>
-    <string name="share_intent_details">Intent Details teilen</string>
-    <string name="share">Teilen</string>
-    <string name="send_test_intent_title">Test Intent senden</string>
-    <string name="reset_intent">Intent zurücksetzen</string>
-    <string name="resend_intent">Intent senden</string>
-    <string name="rate_this_app_title">Die App bewerten</string>
-    <string name="enable_intent_intercept">Abfangen aktivieren</string>
-    <string name="intent_details_copied_to_clipboard">Intent Details in die Zwischenablage kopiert.</string>
-    <string name="send_test_intent_summary">Hier tippen, und dann \'Intent Abfänger\' von der Liste auswählen</string>
-    <string name="view_source_code_title">Quellcode ansehen</string>
-    <string name="send_edited_intent_button">Bearbeiteten Intent senden</string>
+
+    <string name="menu_copy_title">Kopieren</string>
+    <string name="menu_share_title">Teilen</string>
+
+    <string name="settings_license_title">Lizenz</string>
+    <string name="settings_visit_website_title">intrications.com besuchen</string>
+    <string name="settings_visit_google_plus_title">Intrications auf Google+ besuchen</string>
+    <string name="settings_view_source_code_summary">Den \'Intent Abfänger\'-Quellcode auf GitHub ansehen</string>
+    <string name="settings_view_my_other_apps_title">Andere Apps von Intrications ansehen</string>
+    <string name="settings_send_test_intent_title">Test Intent senden</string>
+    <string name="settings_rate_this_app_title">Die App bewerten</string>
+    <string name="settings_enable_intent_intercept_title">Abfangen aktivieren</string>
+    <string name="settings_send_test_intent_summary">Hier tippen, und dann \'Intent Abfänger\' von der Liste auswählen</string>
+    <string name="settings_view_source_code_title">Quellcode ansehen</string>
+    <string name="settings_report_issue_title">Fehler melden</string>
+
+    <string name="button_title_reset_intent">Intent zurücksetzen</string>
+    <string name="button_title_resend_intent">Intent senden</string>
+    <string name="button_title_send_edited_intent">Bearbeiteten Intent senden</string>
+
+    <string name="message_intent_details_copied_to_clipboard">Intent Details in die Zwischenablage kopiert.</string>
+
     <string name="intent_filter_label">Den Intent abfangen</string>
+    <string name="error_extracting_extras">Kann Extras nicht lesen</string>
+    <string name="settings_report_issue_summary">Issue Tracker auf Github öffnen</string>
+    <string name="send_test_intent_content">Test Intent</string>
+    <string name="send_test_intent_chooser_title">Wähle: \'Den Intent abfangen\'</string>
+    <string name="no_items">keine</string>
+    <string name="extra_item_key_title">Key:</string>
+    <string name="extra_item_type_name_list">Liste:</string>
+    <string name="extra_item_value_title">Wert:</string>
+    <string name="extra_item_type_name_title">Typ:</string>
+    <string name="intent_matching_activities_title">AUFRUFBARE ACTIVITIES</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    resources that should NOT be localized and are version independant
+-->
+<resources>
+    <string name="settings_license_summary" translatable="false">Apache License, Version 2.0</string>
+    <string name="no_value_text" translatable="false">null</string>
+    <string name="last_result_message" translatable="false">%s: %s (%s)</string>
+    <string name="mime_type_text_plain" translatable="false">text/plain</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,77 +1,48 @@
 <resources>
     <string name="app_name">Intent Intercept</string>
-    <string name="resend_intent">Resend Intent</string>
-    <string name="reset_intent">Reset Intent</string>
-    <string name="share">Share</string>
-    <string name="intent_details_copied_to_clipboard">Intent details copied to clipboard.</string>
-    <string name="share_intent_details">Share Intent Details</string>
-    <string name="copy">Copy</string>
-    <string name="enable_intent_intercept">Enable interception</string>
+
+    <string name="menu_share_title">Share</string>
+    <string name="menu_copy_title">Copy</string>
+
+    <string name="button_title_resend_intent">Resend Intent</string>
+    <string name="button_title_reset_intent">Reset Intent</string>
+
+    <string name="message_intent_details_copied_to_clipboard">Intent details copied to clipboard.</string>
+    <string name="settings_enable_intent_intercept_title">Enable interception</string>
     <string name="intent_filter_label">Intercept the Intent</string>
-    <string name="send_test_intent_pref" translatable="false">sendTestIntent</string>
-    <string name="intercept_enable_pref" translatable="false">interceptEnabled</string>
-    <string name="send_test_intent_title">Send Test Intent</string>
-    <string name="send_test_intent_summary">Tap this then select Intent Intercept from list</string>
-    <string name="rate_this_app_title">Rate This App</string>
-    <string name="view_my_other_apps_title">View other apps by Intrications</string>
-    <string name="visit_website_title">Visit intrications.com</string>
-    <string name="visit_google_plus_title">Visit Intrications on Google+</string>
-    <string name="view_source_code_title">View Source Code</string>
-    <string name="view_source_code_summary">View Intent Intercept source code on Github</string>
-    <string name="report_issue_title">Report issue</string>
-    <string name="report_issue_summary">View issue tracker on Github</string>
-    <string name="license_summary" translatable="false">Apache License, Version 2.0</string>
-    <string name="license_title">Licence</string>
-    <string name="action">ACTION</string>
-    <string name="null_text">null</string>
-    <string name="data_upper_case">DATA</string>
-    <string name="type">TYPE</string>
-    <string name="uri">URI</string>
-    <string name="categories_upper_case">CATEGORIES</string>
-    <string name="flags">FLAGS</string>
-    <string name="extras">EXTRAS</string>
-    <string name="matching_activities">MATCHING ACTIVITIES</string>
-    <string name="send_edited_intent_button">Send Edited Intent</string>
-    <string name="select_intent_intercept">Select Intent Intercept</string>
-    <string name="test_intent">Test Intent</string>
-    <string name="categories">Categories:</string>
-    <string name="categories_title_bold"><![CDATA[<b><u>CATEGORIES:</u></b><br>]]></string>
-    <string name="none">NONE</string>
-    <string name="bundle_title_bold"><![CDATA[<br><b><u>Bundle:</u></b><br>]]></string>
-    <string name="bundle_title_bold_uppercase"><![CDATA[<br><b><u>BUNDLE:</u></b><br>]]></string>
-    <string name="extra">EXTRA </string>
-    <plurals name="extra_count">
-        <item quantity="one"><![CDATA[<u>EXTRA: %d:</u><br>]]></item>
-        <item quantity="other"><![CDATA[<u>EXTRA: %d:</u><br>]]></item>
-    </plurals>
-    <string name="extras_title_bold"><![CDATA[<br><b><u>EXTRAS:</u></b><br>]]></string>
-    <string name="class_text">Class: </string>
-    <string name="key">Key: </string>
-    <string name="value">Value: </string>
-    <string name="values">Values: </string>
-    <string name="values_break"><![CDATA[Values:<br>]]></string>
-    <string name="error_extracting_extras">ERROR EXTRACTING EXTRAS</string>
-    <string name="error_extracting_extras_red"><![CDATA[<font color="red">Error extracting extras<br></font>]]></string>
-    <string name="no_activities_match_intent">NO ACTIVITIES MATCH THIS INTENT</string>
-    <string name="no_activities_match_intent_title_bold"><![CDATA[<br><b><u>NO ACTIVITIES MATCH THIS INTENT</u></b><br>]]></string>
-    <plurals name="activities_match_intent">
-        <item quantity="one">%d ACTIVITY MATCHES THIS INTENT</item>
-        <item quantity="other">%d ACTIVITIES MATCH THIS INTENT</item>
-    </plurals>
-    <plurals name="activites_match_intent_title_bold">
-        <item quantity="one"><![CDATA[<br><b><u>%d ACTIVITY MATCHES THIS INTENT</u></b><br>]]></item>
-        <item quantity="other"><![CDATA[<br><i><b><u>%d ACTIVITIES MATCH THIS INTENT</u></b></i><br>]]></item>
-    </plurals>
-    <string name="last_result">Last result: </string>
-    <string name="data"> Data: </string>
-    <string name="data_bold"><![CDATA[<b><u>DATA:</u></b> ]]></string>
-    <string name="action_bold"><![CDATA[<b><u>ACTION:</u></b> ]]></string>
-    <string name="type_bold"><![CDATA[<b><u>TYPE:</u></b> ]]></string>
-    <string name="flags_title_bold"><![CDATA[<br><b><u>FLAGS:</u></b><br>]]></string>
-    <string name="text_plain" translatable="false">text/plain</string>
-    <string name="plain_text" translatable="false">plain/text</string>
-    <string name="open_bracket" translatable="false"> (</string>
-    <string name="dash" translatable="false"> - </string>
-    <string name="close_bracket" translatable="false">)</string>
-    <string name="close_bracket_break" translatable="false"><![CDATA[)<br>]]></string>
+    <string name="settings_send_test_intent_title">Send Test Intent</string>
+    <string name="settings_send_test_intent_summary">Tap this then select Intent Intercept from list</string>
+    <string name="settings_rate_this_app_title">Rate This App</string>
+    <string name="settings_view_my_other_apps_title">View other apps by Intrications</string>
+    <string name="settings_visit_website_title">Visit intrications.com</string>
+    <string name="settings_visit_google_plus_title">Visit Intrications on Google+</string>
+    <string name="settings_view_source_code_title">View Source Code</string>
+    <string name="settings_view_source_code_summary">View Intent Intercept source code on Github</string>
+    <string name="settings_report_issue_title">Report issue</string>
+    <string name="settings_report_issue_summary">View issue tracker on Github</string>
+    <string name="settings_license_title">Licence</string>
+    <string name="intent_action_title">ACTION:</string>
+    <string name="intent_data_title">DATA:</string>
+    <string name="intent_mime_type_title">MIME:</string>
+    <string name="intent_uri_title">URI:</string>
+    <string name="intent_flags_title">FLAGS:</string>
+    <string name="intent_matching_activities_title">MATCHING ACTIVITIES:</string>
+    <string name="button_title_send_edited_intent">Send Edited Intent</string>
+
+    <string name="send_test_intent_chooser_title">Select \'Intercept the Intent\'</string>
+    <string name="send_test_intent_content">Test Intent</string>
+    <string name="intent_categories_title">CATEGORY:</string>
+
+    <string name="no_items">none</string>
+	
+	
+    <string name="intent_extras_title">EXTRAS:</string>
+
+    <string name="extra_item_type_name_title">Class: </string>
+    <string name="extra_item_key_title">Key: </string>
+    <string name="extra_item_value_title">Value: </string>
+    <string name="extra_item_type_name_list">List:</string>
+    <string name="error_extracting_extras">Error extracting Extras</string>
+    <string name="last_result_header_title">onActivityResult:</string>
+    <string name="last_result_code_title">resultCode:</string>
 </resources>

--- a/app/src/main/res/xml-v15/enable_disable_settings.xml
+++ b/app/src/main/res/xml-v15/enable_disable_settings.xml
@@ -3,7 +3,7 @@
 
     <SwitchPreference
         android:defaultValue="true"
-        android:key="@string/intercept_enable_pref"
-        android:title="@string/enable_intent_intercept" />
+        android:key="interceptEnabled"
+        android:title="@string/settings_enable_intent_intercept_title" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/enable_disable_settings.xml
+++ b/app/src/main/res/xml/enable_disable_settings.xml
@@ -3,7 +3,7 @@
 
     <CheckBoxPreference
         android:defaultValue="true"
-        android:key="@string/intercept_enable_pref"
-        android:title="@string/enable_intent_intercept" />
+        android:key="interceptEnabled"
+        android:title="@string/settings_enable_intent_intercept_title" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -2,53 +2,53 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <Preference
-        android:key="@string/send_test_intent_pref"
-        android:title="@string/send_test_intent_title"
-        android:summary="@string/send_test_intent_summary">
+        android:key="sendTestIntent"
+        android:title="@string/settings_send_test_intent_title"
+        android:summary="@string/settings_send_test_intent_summary">
         <intent
             android:action="android.intent.action.VIEW"
             android:data="Test Data" >
         </intent>
     </Preference>
     <Preference
-        android:summary="@string/view_source_code_summary"
-        android:title="@string/view_source_code_title" >
+        android:summary="@string/settings_view_source_code_summary"
+        android:title="@string/settings_view_source_code_title" >
         <intent
             android:action="android.intent.action.VIEW"
             android:data="https://github.com/intrications/intent-intercept" >
         </intent>
     </Preference>
     <Preference
-        android:summary="@string/report_issue_summary"
-        android:title="@string/report_issue_title" >
+        android:summary="@string/settings_report_issue_summary"
+        android:title="@string/settings_report_issue_title" >
         <intent
             android:action="android.intent.action.VIEW"
             android:data="https://github.com/intrications/intent-intercept/issues" >
         </intent>
     </Preference>
     <Preference
-        android:title="@string/rate_this_app_title" >
+        android:title="@string/settings_rate_this_app_title" >
         <intent
             android:action="android.intent.action.VIEW"
             android:data="https://play.google.com/store/apps/details?id=uk.co.ashtonbrsc.android.intentintercept" >
         </intent>
     </Preference>
     <Preference
-        android:title="@string/view_my_other_apps_title" >
+        android:title="@string/settings_view_my_other_apps_title" >
         <intent
             android:action="android.intent.action.VIEW"
             android:data="https://play.google.com/store/apps/developer?id=Intrications" >
         </intent>
     </Preference>
     <Preference
-        android:title="@string/visit_website_title" >
+        android:title="@string/settings_visit_website_title" >
         <intent
             android:action="android.intent.action.VIEW"
             android:data="http://www.intrications.com" >
         </intent>
     </Preference>
     <Preference
-        android:title="@string/visit_google_plus_title" >
+        android:title="@string/settings_visit_google_plus_title" >
         <intent
             android:action="android.intent.action.VIEW"
             android:data="https://plus.google.com/114248840147347624819/posts" >
@@ -56,8 +56,8 @@
     </Preference>
     <Preference
         android:key="licence"
-        android:summary="@string/license_summary"
-        android:title="@string/license_title" >
+        android:summary="@string/settings_license_summary"
+        android:title="@string/settings_license_title" >
         <intent
             android:action="android.intent.action.VIEW"
             android:data="http://www.apache.org/licenses/LICENSE-2.0.html" >


### PR DESCRIPTION
... to make it much easier for translators to add a new language. Only 38 items have to be translated instead of 75 before

* renamed string-ids to become more contextsesitive so translaters know more about their meaning
  * Example: strings for the settings activity are prefixed with "settings_"
* renamed some resource-ids  
  * Example: R.id.data becomes R.id.data_edit
  * Example: R.id.activities_layout becomes R.id.intent_matchin_activities_layout
* moved non translatable strings.xml to donottranslate.xml
  * text_plain in strings.xml becomes mime_type_text_plain in donottranslate.xml  
* removed fromatting from string resources to code making translating much easier for translators 
  * the new intent_extras_title replaces the old extras, extra, extra_count, extras_title_bold, bundle_title_bold, bundle_title_bold_uppercase
* moved some string resources back to code. 
  * for example preference-id: @string/intercept_enable_pref
* added those german translations that are not Intend-api specific
* reimplemented parts of getIntentDetailsStrings
